### PR TITLE
Use simpler and proper way to get headless kafka name

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -72,8 +72,7 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
-{{- $name := "cp-kafka-headless" -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-headless" (include "cp-kafka.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: Keyvan Hedayati <k1.hedayati93@gmail.com>

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
