### PR TITLE
Merge confluent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See go/codeowners - automatically generated for confluentinc/cp-helm-charts:
+*	@confluentinc/cluster-management

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def config = jobConfig {
-    slackChannel = 'tools-notifications'
+    slackChannel = 'devprod-notifications'
 }
 
 def job = {

--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "6.1.0"
+apiVersion: v2
+appVersion: "7.2.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.2.0
+version: 0.3.0

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -1,3 +1,5 @@
+{{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
+{{- $persistenceEnabled := and .Values.persistence.enabled (gt $disksPerBroker 0) }}
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else }}
@@ -94,7 +96,7 @@ spec:
             command:
               - sh
               - -ec
-              - /usr/bin/jps | /bin/grep -q SupportedKafka
+              - /usr/bin/jps | /bin/grep -q Kafka
           {{- if not .Values.livenessProbe }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -183,15 +185,29 @@ spec:
         - -exc
         - |
           export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
-          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ template "cp-kafka.fullname" . }}-headless.${POD_NAMESPACE}:9092{{ include "cp-kafka.configuration.advertised.listeners" . }} && \
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ template "cp-kafka.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:9092{{ include "cp-kafka.configuration.advertised.listeners" . }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
-        {{- if .Values.persistence.enabled }}
-          {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
-          {{- range $k, $e := until $disksPerBroker }}
-          - name: datadir-{{$k}}
-            mountPath: /opt/kafka/data-{{$k}}
+          {{- if $persistenceEnabled }}
+            {{- range $k, $e := until $disksPerBroker }}
+            - name: datadir-{{$k}}
+              mountPath: /opt/kafka/data-{{$k}}
+            {{- end }}
           {{- end }}
+      initContainers:
+        {{- if and .Values.initChownData.enabled $persistenceEnabled }}
+        - name: init-chown-data
+          image: {{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}
+          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - "for d in /opt/kafka/data-*; do u=$(stat -c \"%u\" $d/logs); if [ $u != {{ .Values.initChownData.uid }} ] && [ $u != 65534 ]; then chown -R {{ .Values.initChownData.uid }} $d; fi; done"
+          volumeMounts:
+            {{- range $k, $e := until $disksPerBroker }}
+            - name: datadir-{{$k}}
+              mountPath: /opt/kafka/data-{{$k}}
+            {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -12,7 +12,7 @@ brokers: 3
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-server/
 image: confluentinc/cp-server
-imageTag: 6.1.0
+imageTag: 7.2.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -82,6 +82,14 @@ persistence:
 
   disksPerBroker: 1
 
+initChownData:
+  enabled: false
+  image:
+    repository: busybox
+    tag: 1.35.0
+    pullPolicy: IfNotPresent
+  uid: 1000
+
 ## Kafka JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"
 

--- a/charts/cp-ksql-server/Chart.yaml
+++ b/charts/cp-ksql-server/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "6.1.0"
+apiVersion: v2
+appVersion: "7.2.0"
 description: A Helm chart for Confluent KSQL Server on Kubernetes
 name: cp-ksql-server
-version: 0.2.0
+version: 0.3.0

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-ksql-server/
 image: confluentinc/cp-ksqldb-server
-imageTag: 6.1.0
+imageTag: 7.2.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-schema-registry/Chart.yaml
+++ b/charts/cp-schema-registry/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6.1.0"
+appVersion: "7.2.0"
 description: A Helm chart for Confluent Schema Registry on Kubernetes
 name: cp-schema-registry
-version: 0.2.0
+version: 0.3.0

--- a/charts/cp-schema-registry/templates/ingress.yaml
+++ b/charts/cp-schema-registry/templates/ingress.yaml
@@ -1,6 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cp-schema-registry.fullname" . -}}
+{{- $pathType := .Values.ingress.pathType }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -31,9 +36,19 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: schema-registry
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: schema-registry
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-schema-registry/
 image: confluentinc/cp-schema-registry
-imageTag: 6.1.0
+imageTag: 7.2.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -94,7 +94,6 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     imagePullPolicy: IfNotPresent
     port: 5556
-
     resources: {}
 
 ingress:
@@ -105,6 +104,8 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
+
+  pathType: ImplementationSpecific
 
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -72,9 +72,9 @@ affinity: {}
 ## Privilege and access control settings for a Pod or Container
 ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
-  runAsUser: 10001
-  runAsGroup: 10001
-  fsGroup: 10001
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
   runAsNonRoot: true
 
 ## Monitoring

--- a/charts/cp-zookeeper/Chart.yaml
+++ b/charts/cp-zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "6.1.0"
+apiVersion: v2
+appVersion: "7.2.0"
 description: A Helm chart for Confluent Zookeeper on Kubernetes
 name: cp-zookeeper
-version: 0.2.0
+version: 0.3.0

--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -130,6 +130,8 @@ spec:
         env:
         - name : KAFKA_HEAP_OPTS
           value: "{{ .Values.heapOptions }}"
+        - name : KAFKA_OPTS
+          value: "{{ .Values.kafkaOpts }}"
         {{- if .Values.jmx.port }}
         - name : KAFKA_JMX_PORT
           value: "{{ .Values.jmx.port }}"
@@ -169,6 +171,21 @@ spec:
           mountPath: /var/lib/zookeeper/data
         - name: datalogdir
           mountPath: /var/lib/zookeeper/log
+      initContainers:
+        {{- if and .Values.initChownData.enabled .Values.persistence.enabled }}
+        - name: init-chown-data
+          image: {{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}
+          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - "u=$(stat -c \"%u\" /var/lib/zookeeper/data/myid); if [ $u != {{ .Values.initChownData.uid }} ] && [ $u != 65534 ]; then chown -R {{ .Values.initChownData.uid }} /var/lib/zookeeper/data /var/lib/zookeeper/log; fi"
+          volumeMounts:
+            - name: datadir
+              mountPath: /var/lib/zookeeper/data
+            - name: datalogdir
+              mountPath: /var/lib/zookeeper/log
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -15,7 +15,7 @@ servers: 3
 ## Images Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-zookeeper/
 image: confluentinc/cp-zookeeper
-imageTag: 6.1.0
+imageTag: 7.2.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -52,6 +52,7 @@ maxClientCnxns: 60
 autoPurgeSnapRetainCount: 3
 autoPurgePurgeInterval: 24
 
+kafkaOpts: "-Dzookeeper.4lw.commands.whitelist=ruok"
 ## Zookeeper JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"
 
@@ -77,6 +78,13 @@ persistence:
   dataLogDirSize: 5Gi
   # dataLogDirStorageClass: ""
 
+initChownData:
+  enabled: false
+  image:
+    repository: busybox
+    tag: 1.35.0
+    pullPolicy: IfNotPresent
+  uid: 1000
 
 ## Pod Compute Resources
 ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/


### PR DESCRIPTION
- merge upstream changes
- upgraded Kafka, Zookeeper and Schema
- compatibility with K8S 1.22+ Ingress
- fix file permissions when upgrading from confluent 5.x to 6.x+, by setting `initChownData.enabled: true` in cp-zookeeper and cp-kafka
- fix cp-kafka advertised host to append `svc.cluster.local`
- fix cp-kafka liveness command for confluent all versions 5.x+
- fix cp-zookeeper liveness command by whitelisting the `ruok` command in cp-zookeeper versions 6.x+.