### PR TITLE
Fix image name for cp-kafka

### DIFF
--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "7.2.9"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.3.4
+version: 0.3.5

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -11,7 +11,7 @@ brokers: 3
 
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-server/
-image: confluentinc/cp-server
+image: confluentinc/cp-kafka
 imageTag: 7.2.9
 
 ## Specify a imagePullPolicy


### PR DESCRIPTION
Was `cp-server` should be `cp-kafka`.