### PR TITLE
Set jaas password secret in ksql server container

### DIFF
--- a/charts/cp-ksql-server/Chart.yaml
+++ b/charts/cp-ksql-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: 7.6.0
 description: A Helm chart for Confluent KSQL Server on Kubernetes
 name: cp-ksql-server
-version: 0.3.4
+version: 0.4.1

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -100,6 +100,13 @@ spec:
           - name: {{ printf "KSQL_%s" $key | replace "." "_" | upper | quote }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.secret.jaas.name }}
+          - name: KSQL_SASL_JAAS_CONFIG
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secret.jaas.name }}
+                key: {{ .Values.secret.jaas.key }}
+          {{- end }}
           {{- if .Values.jmx.port }}
           - name: JMX_PORT
             value: "{{ .Values.jmx.port }}"

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -103,3 +103,9 @@ cp-schema-registry:
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html
 configurationOverrides: {}
   # "ksql.streams.producer.retries": "2147483647"
+
+secret:
+  # -- Secret for the Kafka SASL JAAS configuration. Sets env var `KSQL_SASL_JAAS_CONFIG` in the deployment.
+  jaas:
+    name:
+    key:


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR add a value to define a JAAS secret used to connecto to Kafka. The secret is passed as the KSQL_SASL_JAAS_CONFIG environmental variable.

## How was this patch tested?
I tested this to work on a local k3d/k3s cluster.